### PR TITLE
Added the `beforeDatasetsUpdate` lifecycle hook in order to refresh the callbacks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,7 +251,15 @@ const ChartJSdragDataPlugin = {
     attachListeners(chartInstance)
   },
   afterInit: function (chartInstance) {
-    attachListeners(chartInstance)
+    if (chartInstance.config.options.plugins && chartInstance.config.options.plugins.dragData) {
+      const pluginOptions = chartInstance.config.options.plugins.dragData
+      select(chartInstance.canvas).call(
+        drag().container(chartInstance.canvas)
+          .on('start', e => getElement(e.sourceEvent, chartInstance, pluginOptions.onDragStart))
+          .on('drag', e => updateData(e.sourceEvent, chartInstance, pluginOptions, pluginOptions.onDrag))
+          .on('end', e => dragEndCallback(e.sourceEvent, chartInstance, pluginOptions.onDragEnd))
+      )
+    }
   },
   beforeEvent: function (chart) {
     if (isDragging) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import {Chart} from 'chart.js'
 import {drag} from 'd3-drag'
 import {select} from 'd3-selection'
 
-let element, yAxisID, xAxisID, rAxisID, type, stacked, floatingBar, initValue, curDatasetIndex, curIndex, eventSettings
+let element, yAxisID, xAxisID, rAxisID, type, stacked, floatingBar, initValue, curDatasetIndex, curIndex, eventSettings, onDrag, onDragEnd, onDragStart
 let isDragging = false
 
 function getSafe(func) {

--- a/src/index.js
+++ b/src/index.js
@@ -226,11 +226,15 @@ const dragEndCallback = (e, chartInstance, callback) => {
   }
 }
 
-const ChartJSdragDataPlugin = {
-  id: 'dragdata',
-  afterInit: function (chartInstance) {    
-    if (chartInstance.config.options.plugins && chartInstance.config.options.plugins.dragData) {
-      const pluginOptions = chartInstance.config.options.plugins.dragData
+const attachListeners = (chartInstance) => {
+  if (chartInstance.config.options.plugins && chartInstance.config.options.plugins.dragData) {
+    const pluginOptions = chartInstance.config.options.plugins.dragData
+
+    if (pluginOptions.onDragStart != onDragStart || pluginOptions.onDrag != onDrag || pluginOptions.onDragEnd != onDragEnd) {
+      onDragStart = pluginOptions.onDragStart
+      onDrag = pluginOptions.onDrag
+      onDragEnd = pluginOptions.onDragEnd
+
       select(chartInstance.canvas).call(
         drag().container(chartInstance.canvas)
           .on('start', e => getElement(e.sourceEvent, chartInstance, pluginOptions.onDragStart))
@@ -238,6 +242,16 @@ const ChartJSdragDataPlugin = {
           .on('end', e => dragEndCallback(e.sourceEvent, chartInstance, pluginOptions.onDragEnd))
       )
     }
+  }
+}
+
+const ChartJSdragDataPlugin = {
+  id: 'dragdata',
+  beforeDatasetsUpdate: function (chartInstance) {
+    attachListeners(chartInstance)
+  },
+  afterInit: function (chartInstance) {
+    attachListeners(chartInstance)
   },
   beforeEvent: function (chart) {
     if (isDragging) {


### PR DESCRIPTION
# Problem
- If a chart's `onDragStart`, `onDrag`, or `onDragEnd` callbacks are changed as a form of data update and the `chart.update()` function is called then the old callbacks are still run instead of potential new ones.

# Solution
- The `beforeDatasetsUpdate` lifecycle hook was added as per the diagram found [here](https://www.chartjs.org/docs/latest/developers/plugins.html#chart-update). The documentation can be found [here](https://www.chartjs.org/docs/latest/api/interfaces/Plugin.html#beforedatasetsupdate).
- The callbacks are compared with the cached callbacks from the initial on `afterInit` hook. If the callbacks are different then the listeners are re attached. 