### PR TITLE
Use up-to-date configuration reference in callbacks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -230,12 +230,11 @@ const ChartJSdragDataPlugin = {
   id: 'dragdata',
   afterInit: function (chartInstance) {    
     if (chartInstance.config.options.plugins && chartInstance.config.options.plugins.dragData) {
-      const pluginOptions = chartInstance.config.options.plugins.dragData
       select(chartInstance.canvas).call(
         drag().container(chartInstance.canvas)
-          .on('start', e => getElement(e.sourceEvent, chartInstance, pluginOptions.onDragStart))
-          .on('drag', e => updateData(e.sourceEvent, chartInstance, pluginOptions, pluginOptions.onDrag))
-          .on('end', e => dragEndCallback(e.sourceEvent, chartInstance, pluginOptions.onDragEnd))
+          .on('start', e => getElement(e.sourceEvent, chartInstance, chartInstance.config.options.plugins.dragData.onDragStart))
+          .on('drag', e => updateData(e.sourceEvent, chartInstance, chartInstance.config.options.plugins.dragData, chartInstance.config.options.plugins.dragData.onDrag))
+          .on('end', e => dragEndCallback(e.sourceEvent, chartInstance, chartInstance.config.options.plugins.dragData.onDragEnd))
       )
     }
   },


### PR DESCRIPTION
**Summary**
Callbacks are registered during `afterInit`, however they were using a fixed reference to the `dragData` object using the chart instance object at time of initialization. That's fine *only* if the configuration options never change. However if, as was the case for me, the user is changing their callback definitions and updating the options object accordingly, the new callbacks would never be used by this plugin.

**Test Plan**
- Instantiate a chart with one set of callbacks
- Rerender the chart with a new set of callbacks
- Plugin uses the most recent callbacks