### PR TITLE
fix(ci): manually trigger postinstall in CI workflow if cache was used instead of npm i

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
 
+      # since playwright installs binaries of browsers with 'npx playwright install' triggered from the 'postinstall' script,
+      # it won't happen when no 'npm install' is run, which is the case for when the '...-npm-...' cache is restored
+      # for that reason, there is a need to run this command here
+      - name: Run 'npm run postinstall' manually if the cache was used instead of npm install
+        if: steps.cache-node_modules.outputs.cache-hit == 'true'
+        run: npm run postinstall
+
       - name: Install playwright dependency libraries
         run: npx playwright install-deps
 


### PR DESCRIPTION
## Describe your changes

Since the recent changes applied a cache to ci workflows, `npm ci` is not run when the cache is restored, which in turn implies that the `postinstall` script won't be invoked. The `postinstall` script, however, triggered `npx playwright install`, which installed playwright's browsers binaries to `~/.cache/ms-playwright`.
What would fix the problem would either be running this manually if the cache was restored instead of `npm ci` having been run, or to cache `~/.cache/ms-playwright`.

As others have already encountered this problem as well and [noticed here](https://github.com/microsoft/playwright/issues/7249) that download times are very fast, this PR introduces the first approach: to run `npm run postinstall` manuall, which is also more scalable since this will always download the newest supported browser binaries; for speed-up, this step is only added to `ci.yml`, but not to `cd.yml` (which does not need neither playwright, nor lefthook).

## Linked issues (if any)

<!-- either list the issues below using #issue-number format -->


<!-- or uncomment the below and remove the above listing -->
N/A

## Checklist before requesting a review

- [x] E2E tests' snapshots (screenshots) are up-to-date
- [x] documentation is up-to-date
