### PR TITLE
fix(cd): install optional packages manually in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,12 @@ jobs:
             ${{ runner.os }}-npm-${{ hashFiles('/package-lock.json') }}
             ${{ runner.os }}-npm-
 
+      # since npm ci installs only dependencies in package-lock.json, it may be that the package-lock.json pushed
+      # has been generated on non-linux, making the installed node_modules lack packages needed by the linux runner
+      - name: Ensure lefthook-linux-x64 & @rollup/rollup-linux-x64-gnu are installed
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: npm i --legacy-peer-deps lefthook-linux-x64 @rollup/rollup-linux-x64-gnu
+
       - name: Install npm dependencies
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps


### PR DESCRIPTION
## Describe your changes

Workaround for CD workflow not installing optional dependencies probably due to `npm ci` when there is no cached version of `node_modules` and `package-lock.json` comes from a non-linux environment.

## Linked issues (if any)

N/A

## Checklist before requesting a review

- [x] E2E tests' snapshots (screenshots) are up-to-date
- [x] documentation is up-to-date
