### PR TITLE
fix: demos onHover showing grab cursor icon at all times

### DIFF
--- a/pages/dist-demos/bar-floating-horizontal.html
+++ b/pages/dist-demos/bar-floating-horizontal.html
@@ -142,7 +142,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bar-floating.html
+++ b/pages/dist-demos/bar-floating.html
@@ -139,7 +139,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bar-horizontal.html
+++ b/pages/dist-demos/bar-horizontal.html
@@ -126,7 +126,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bar-stacked-horizontal.html
+++ b/pages/dist-demos/bar-stacked-horizontal.html
@@ -131,7 +131,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bar-stacked.html
+++ b/pages/dist-demos/bar-stacked.html
@@ -128,7 +128,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bar.html
+++ b/pages/dist-demos/bar.html
@@ -125,7 +125,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bubble-x-only.html
+++ b/pages/dist-demos/bubble-x-only.html
@@ -129,7 +129,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/bubble.html
+++ b/pages/dist-demos/bubble.html
@@ -126,7 +126,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/gantt.html
+++ b/pages/dist-demos/gantt.html
@@ -199,7 +199,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/line-categorical.html
+++ b/pages/dist-demos/line-categorical.html
@@ -125,7 +125,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/line-dual-y-axis.html
+++ b/pages/dist-demos/line-dual-y-axis.html
@@ -143,7 +143,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/line-linear-custom-interaction.html
+++ b/pages/dist-demos/line-linear-custom-interaction.html
@@ -171,7 +171,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/line-linear.html
+++ b/pages/dist-demos/line-linear.html
@@ -142,7 +142,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/polar.html
+++ b/pages/dist-demos/polar.html
@@ -125,7 +125,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/radar.html
+++ b/pages/dist-demos/radar.html
@@ -125,7 +125,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/dist-demos/scatter.html
+++ b/pages/dist-demos/scatter.html
@@ -129,7 +129,7 @@
 									const point = e.chart.getElementsAtEventForMode(
 										e,
 										e.chart.options.interaction.mode,
-										{ intersect: false },
+										{ intersect: true },
 										false,
 									);
 									if (point.length) e.native.target.style.cursor = "grab";

--- a/pages/src/templates/layout.html.ejs
+++ b/pages/src/templates/layout.html.ejs
@@ -197,7 +197,7 @@
 								const point = e.chart.getElementsAtEventForMode(
 									e,
 									e.chart.options.interaction.mode,
-									{ intersect: false },
+									{ intersect: true },
 									false,
 								);
 								if (point.length) e.native.target.style.cursor = "grab";


### PR DESCRIPTION
## Describe your changes

Currently, due to `intersection: false` option passed to `getElementsAtEventForMode` in `onHover` chart hook in demos, the grab cursor is shown at all times (thanks to no-intersection mode picking nearby points). This PR brings `intersection: true`, which limits this cursor icon to only situations when the cursor actually hovers a data point.

## Linked issues (if any)

N/A

## Checklist before requesting a review

- [x] E2E tests' snapshots (screenshots) are up-to-date
- [x] documentation is up-to-date
