### PR TITLE
fix: interface DragEventCallback missing alternative void return type

### DIFF
--- a/src/types/EventTypes.ts
+++ b/src/types/EventTypes.ts
@@ -14,4 +14,4 @@ export type DragEventCallback<TType extends ChartType> = (
 	index: number,
 	/** the current value of the data point */
 	value: ChartDataItemType<TType>,
-) => boolean;
+) => boolean | void;


### PR DESCRIPTION
## Describe your changes

Typings for `DragEventCallback` requires that a callback returns `boolean`, while it should be `boolean | void` to allow for not returning anything for simplicity.

## Linked issues (if any)

N/A
## Checklist before requesting a review

- [x] E2E tests' snapshots (screenshots) are up-to-date
- [x] documentation is up-to-date
