### PR TITLE
fix(docs): update README.md, CHANGELOG.md with breaking change information about plugin registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [2.3.0](https://github.com/artus9033/chartjs-plugin-dragdata/compare/v2.2.5...v2.3.0) (2024-08-17)
 
 
+### ⚠ BREAKING CHANGES
+
+* Now the plugin does not self-register and manual registration is required (either via `Chart.register` or by listing the plugin in chart options)
+
 ### Features
 
 * demos & master branch coverage ([#133](https://github.com/artus9033/chartjs-plugin-dragdata/issues/133)) ([45fa08d](https://github.com/artus9033/chartjs-plugin-dragdata/commit/45fa08d65aa2b2fb3b4f4add3e410c5fbce62dec))

--- a/README.md
+++ b/README.md
@@ -94,6 +94,57 @@ In browsers, you may simply add the following script tag:
 
 Or, download a release archive file from [releases](https://github.com/artus9033/chartjs-plugin-dragdata/releases).
 
+## Getting started
+
+> [!IMPORTANT]  
+> Versions `>= 3.0.0` require [manual registration](https://www.chartjs.org/docs/latest/developers/plugins.html#using-plugins).
+
+Just importing or loading the plugin script will not make dragging work. As it is usually done with chart.js plugins, since `v3.0.0` the plugin no longer self-registers globally in Chart.js and you must [register it](https://www.chartjs.org/docs/latest/developers/plugins.html#using-plugins) manually.
+
+### Global registration
+
+As any chart.js plugin, the dragdata plugin can be registered either globally for all charts (using `Chart.register(ChartJSDragDataPlugin)`), or on a per-chart basis (by specifying `plugins: [ChartJSDragDataPlugin]` in chart config).
+
+#### Bundler
+
+If you are using a bundler (e.g. Webpack, Rollup, Parcel or similar, or a framework like React or Angular):
+
+In ESM modules:
+
+```ts
+import Chart from "chart.js/auto";
+import ChartJSDragDataPlugin from "chartjs-plugin-dragdata";
+
+Chart.register(ChartJSDragDataPlugin);
+```
+
+Or in CJS modules:
+
+```js
+const Chart = require("chart.js/auto");
+const ChartJSDragDataPlugin = require("chartjs-plugin-dragdata");
+
+Chart.register(ChartJSDragDataPlugin);
+```
+
+#### Script tag
+
+Or, if you are using a script tag, both chart.js & chartjs-plugin-dragdata are available as global variables (`Chart` & `ChartJSDragDataPlugin`):
+
+```js
+Chart.register(ChartJSDragDataPlugin);
+```
+
+### Per-chart registration
+
+If you want to apply the plugin just to selected charts, you can list the plugin in chart config:
+
+```ts
+new Chart(ctx, {
+	plugins: [ChartJSDragDataPlugin],
+});
+```
+
 ## Configuration
 
 The following Chart.js sample configuration displays (_most_) of the available


### PR DESCRIPTION
## Describe your changes

The plugin requires manual registration starting from `v3.0.0`, yet this information is not emphasized in the README, nor in the CHANGELOG.

## Linked issues (if any)

N/A

## Checklist before requesting a review

- [x] E2E tests' snapshots (screenshots) are up-to-date
- [x] documentation is up-to-date
