### PR TITLE
fix(ci): proper caching of node_modules

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,11 @@
 name: Setup
 description: Setup environment for Node.JS & install dependencies, including platform-specific lefthook & rollup bindings
 
+outputs:
+  node-modules-cache-hit:
+    description: "Whether the node_modules cache was hit ('true' or 'false')"
+    value: ${{ steps.cache-node-modules.outputs.cache-hit }}
+
 runs:
   using: composite
   steps:
@@ -17,14 +22,21 @@ runs:
         node-version-file: ".nvmrc"
         cache: "npm"
 
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      id: cache-node-modules
+      with:
+        path: "node_modules"
+        key: node-modules-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
     # since npm ci installs only dependencies in package-lock.json, it may be that the package-lock.json pushed
     # has been generated on non-linux, making the installed node_modules lack packages needed by the linux runner
     - name: Ensure lefthook-linux-x64 & @rollup/rollup-linux-x64-gnu are installed
-      if: steps.setup-node.outputs.cache-hit != 'true'
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: npm i lefthook-linux-x64 @rollup/rollup-linux-x64-gnu
 
     - name: Install npm dependencies
-      if: steps.setup-node.outputs.cache-hit != 'true'
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup environment
+        id: setup-environment
         uses: ./.github/actions/setup
 
       # since playwright installs binaries of browsers with 'npx playwright install' triggered from the 'prepare' script,
       # it won't happen when no 'npm install' is run, which is the case for when the '...-npm-...' cache is restored
       # for that reason, there is a need to run this command here
       - name: Run 'npm run prepare' manually if the cache was used instead of npm install
-        if: steps.setup-node.outputs.cache-hit == 'true'
+        if: steps.setup-environment.outputs.node-modules-cache-hit == 'true'
         run: npm run prepare
 
       - name: Install playwright dependency libraries


### PR DESCRIPTION
## Describe your changes

PR #157 introduced a refactor to GH workflows, adding a `setup` action that extracts some common setup logic used both by CI and CD workflows. This accidentally dropped the caching of node_modules and didn't adjust other steps to this change. Since installation of local npm dependencies takes around 2 minutes, it is better to cache them in the case of this project, which is brought back by this PR.

## Linked issues (if any)

N/A

## Checklist before requesting a review

- ~~[ ] E2E tests' snapshots (screenshots) are up-to-date~~
- ~~[ ] documentation is up-to-date~~
